### PR TITLE
Support modified date for RSS

### DIFF
--- a/org.rssowl.core/plugin.xml
+++ b/org.rssowl.core/plugin.xml
@@ -58,6 +58,9 @@
             class="org.rssowl.core.internal.interpreter.DublinCoreNamespaceHandler"
             namespaceURI="http://purl.org/dc/elements/1.1/"/>
       <namespaceHandler
+            class="org.rssowl.core.internal.interpreter.AtomNamespaceHandler"
+            namespaceURI="http://purl.org/atom/ns#"/>
+      <namespaceHandler
             class="org.rssowl.core.internal.interpreter.SyndicationNamespaceHandler"
             namespaceURI="http://purl.org/rss/1.0/modules/syndication/"/>
       <namespaceHandler

--- a/org.rssowl.core/src/org/rssowl/core/internal/interpreter/AtomInterpreter.java
+++ b/org.rssowl.core/src/org/rssowl/core/internal/interpreter/AtomInterpreter.java
@@ -80,7 +80,7 @@ public class AtomInterpreter extends BasicInterpreter {
       Attribute attribute = (Attribute) iter.next();
       String name = attribute.getName();
 
-      /* Check wether this Attribute is to be processed by a Contribution */
+      /* Check whether this Attribute is to be processed by a Contribution */
       if (processAttributeExtern(attribute, feed))
         continue;
 
@@ -99,7 +99,7 @@ public class AtomInterpreter extends BasicInterpreter {
       Element child = (Element) iter.next();
       String name = child.getName().toLowerCase();
 
-      /* Check wether this Element is to be processed by a Contribution */
+      /* Check whether this Element is to be processed by a Contribution */
       if (processElementExtern(child, feed))
         continue;
 

--- a/org.rssowl.core/src/org/rssowl/core/internal/interpreter/AtomNamespaceHandler.java
+++ b/org.rssowl.core/src/org/rssowl/core/internal/interpreter/AtomNamespaceHandler.java
@@ -1,0 +1,72 @@
+/*   **********************************************************************  **
+ **   Copyright notice                                                       **
+ **                                                                          **
+ **   (c) 2005-2009 RSSOwl Development Team                                  **
+ **   http://www.rssowl.org/                                                 **
+ **                                                                          **
+ **   All rights reserved                                                    **
+ **                                                                          **
+ **   This program and the accompanying materials are made available under   **
+ **   the terms of the Eclipse Public License v1.0 which accompanies this    **
+ **   distribution, and is available at:                                     **
+ **   http://www.rssowl.org/legal/epl-v10.html                               **
+ **                                                                          **
+ **   A copy is found in the file epl-v10.html and important notices to the  **
+ **   license from the team is found in the textfile LICENSE.txt distributed **
+ **   in this package.                                                       **
+ **                                                                          **
+ **   This copyright notice MUST APPEAR in all copies of the file!           **
+ **                                                                          **
+ **   Contributors:                                                          **
+ **     RSSOwl Development Team - initial API and implementation             **
+ **                                                                          **
+ **  **********************************************************************  */
+
+package org.rssowl.core.internal.interpreter;
+
+import org.jdom.Attribute;
+import org.jdom.Element;
+import org.rssowl.core.interpreter.INamespaceHandler;
+import org.rssowl.core.persist.INews;
+import org.rssowl.core.persist.IPersistable;
+import org.rssowl.core.util.DateUtils;
+
+/**
+ * Handler for the Atom Namespace.
+ * <p>
+ * Namespace Prefix: atom<br>
+ * Namespace URI: http://purl.org/atom/ns#
+ * </p>
+ *
+ * @author bpasero
+ */
+public class AtomNamespaceHandler implements INamespaceHandler {
+
+  /*
+   * @see
+   * org.rssowl.core.interpreter.INamespaceHandler#processElement(org.jdom.Element
+   * , org.rssowl.core.interpreter.types.IExtendableType)
+   */
+  public void processElement(Element element, IPersistable type) {
+    String name = element.getName().toLowerCase();
+
+    /* Modified / Updated */
+    if ("modified".equals(name) || "updated".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
+      if (type instanceof INews)
+        ((INews) type).setModifiedDate(DateUtils.parseDate(element.getText()));
+    }
+
+    /* Issued / Created / Published */
+    else if ("issued".equals(name) || "created".equals(name) || "published".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+      if (type instanceof INews)
+        ((INews) type).setPublishDate(DateUtils.parseDate(element.getText()));
+    }
+  }
+
+  /*
+   * @see
+   * org.rssowl.core.interpreter.INamespaceHandler#processAttribute(org.jdom
+   * .Attribute, org.rssowl.core.interpreter.types.IExtendableType)
+   */
+  public void processAttribute(Attribute attribute, IPersistable type) {}
+}

--- a/org.rssowl.core/src/org/rssowl/core/internal/interpreter/DublinCoreNamespaceHandler.java
+++ b/org.rssowl.core/src/org/rssowl/core/internal/interpreter/DublinCoreNamespaceHandler.java
@@ -91,6 +91,12 @@ public class DublinCoreNamespaceHandler implements INamespaceHandler {
         ((INews) type).setPublishDate(DateUtils.parseDate(element.getText()));
     }
 
+    /* Modified date */
+    else if ("modified".equals(name)) { //$NON-NLS-1$
+      if (type instanceof INews)
+        ((INews) type).setModifiedDate(DateUtils.parseDate(element.getText()));
+    }
+
     /* Creator */
     else if ("creator".equals(name)) { //$NON-NLS-1$
       IPerson person = Owl.getModelFactory().createPerson(null, type);

--- a/org.rssowl.core/src/org/rssowl/core/internal/interpreter/RSSInterpreter.java
+++ b/org.rssowl.core/src/org/rssowl/core/internal/interpreter/RSSInterpreter.java
@@ -394,7 +394,7 @@ public class RSSInterpreter extends BasicInterpreter {
     INews news = Owl.getModelFactory().createNews(null, feed, new Date(System.currentTimeMillis() - (fNewsCounter++ * 1)));
     news.setBase(feed.getBase());
 
-    /* Check wether the Attributes are to be processed by a Contribution */
+    /* Check whether the Attributes are to be processed by a Contribution */
     processNamespaceAttributes(element, news);
 
     /* Interpret Children */
@@ -403,7 +403,7 @@ public class RSSInterpreter extends BasicInterpreter {
       Element child = (Element) iter.next();
       String name = child.getName().toLowerCase();
 
-      /* Check wether this Element is to be processed by a Contribution */
+      /* Check whether this Element is to be processed by a Contribution */
       if (processElementExtern(child, news))
         continue;
 


### PR DESCRIPTION
RSS does not know the modified date for items.

However, it's possible to use other namespaces providing a modified item property, see http://grumet.net/weblog/archives/rss-with-atom-example.html

```
<dc:modified>2013-09-01T06:07:58+02:00</dc:modified>
<atom:modified>2013-09-01T06:07:58+02:00</atom:modified>
```
1. I've added the modified date to Dublin Core handler.
2. I've added a new Atom handler reading the modified date.
3. Fixed some typos.

BTW: I could not run automatic tests since there is a problem with my Eclipse 4.3 and RSS tests.

It would be great if RSSOwl, my daily RSS newsreader, would support modified dates for RSS items.
